### PR TITLE
add more support for commercial zips

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"async": "~0.1.22",
 		"colors": "0.6.0-1",
 		"rimraf": "~2.0.2",
-		"unzip": "~0.0.4",
+		"unzip": "~0.1.8",
 		"line-input-stream": "1.0.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This pull tries to be more intelligent about extracting the contents of ZIP files.  When modifying the update script for commercial GeoIP, the directory structure containing dynamic names with dats 'n' stuff just hurt too much.

The main change here was only extracing files from the ZIP which the update-in-question needs, and extracting them to the current directory (as long as the updater is using a "serial"-aync call, we'll be safe for collissions), which needed a more modern unzip, and copying the bits to ignore the commercial file header line.
