### PR TITLE
Add continent code to geoip information.

### DIFF
--- a/lib/geoip.js
+++ b/lib/geoip.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var net = require('net');
 var path = require('path');
+var countries = require('countries-list').countries;
 
 fs.existsSync = fs.existsSync || path.existsSync;
 
@@ -75,6 +76,7 @@ function lookup4(ip) {
 		country: '',
 		region: '',
 		city: '',
+		continent: '',
 		ll: [0, 0]
 	};
 
@@ -109,6 +111,9 @@ function lookup4(ip) {
 				geodata.metro = locBuffer.readInt32BE((locId * locRecordSize) + 12);
 				geodata.zip = locBuffer.readInt32BE((locId * locRecordSize) + 16);
 				geodata.city = locBuffer.toString('utf8', (locId * locRecordSize) + 20, (locId * locRecordSize) + locRecordSize).replace(/\u0000.*/, '');
+				if (geodata.country in countries) {
+					geodata.continent = countries[geodata.country].continent;
+				}
 			}
 
 			return geodata;
@@ -137,6 +142,7 @@ function lookup6(ip) {
 		country: '',
 		region: '',
 		city: '',
+		continent: '',
 		ll: [0, 0]
 	};
 
@@ -183,6 +189,9 @@ function lookup6(ip) {
 				geodata.region = buffer.toString('utf8', (line * recordSize) + 34, (line * recordSize) + 36).replace(/\u0000.*/, '');
 				geodata.ll = [buffer.readInt32BE((line * recordSize) + 36) / 10000, buffer.readInt32BE((line * recordSize) + 40) / 10000];
 				geodata.city = buffer.toString('utf8', (line * recordSize) + 44, (line * recordSize) + recordSize).replace(/\u0000.*/, '');
+				if (geodata.country in countries) {
+					geodata.continent = countries[geodata.country].continent;
+				}
 			}
 
 			// We do not currently have detailed region/city info for IPv6, but finally have coords

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"async": "^2.1.1",
 		"colors": "^1.1.2",
+		"countries-list": "^1.4.1",
 		"glob": "^7.1.1",
 		"iconv-lite": "^0.4.13",
 		"lazy": "^1.0.11",

--- a/test/tests.js
+++ b/test/tests.js
@@ -42,6 +42,16 @@ module.exports = {
 		test.done();
 	},
 
+	testContinent: function(test) {
+		test.expect(1);
+
+		var actual = geoip.lookup("104.7.14.245");
+
+		test.equal(actual.continent, "NA");
+
+		test.done();
+	},
+
 	testIPv4MappedIPv6: function (test) {
 		test.expect(2);
 


### PR DESCRIPTION
Using [countries-list](https://www.npmjs.com/package/countries-list) to map ISO 3166 country codes to continent.

As far as I can tell there is no standard mapping.  For example, most mappings that I can find put Turkey in Asia, but Maxmind puts it in Europe.  Someone's created a [bug](https://sourceforge.net/p/geoip/bugs/15/) for this in the geoip sourceforge(!?) project but it is a subjective matter.  [Wikipedia](https://en.wikipedia.org/wiki/List_of_sovereign_states_and_dependent_territories_by_continent_(data_file)) lists Turkey twice, once for each continent.