### PR TITLE
Fix checksum checking in updatedb script

### DIFF
--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -158,7 +158,7 @@ function check(database, cb) {
 	}
     
 	//read existing checksum file
-	fs.readFile(path.join(dataPath, database.type+".checksum"), function(err, data) {
+	fs.readFile(path.join(dataPath, database.type+".checksum"), {encoding: 'utf8'}, function(err, data) {
 		if (!err && data && data.length) {
 			database.checkValue = data;
 		}


### PR DESCRIPTION
update.js did not specify the encoding argument to fs.readFile when reading the current checksum, which made fs.readFile return a Buffer, not a string, and caused every every run of updatedb.js redownload the file every time even if it has already been updated.
This commit fixes it by adding the encoding argument.