### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
This PR adds a very basic CI workflow that only checks if the unit tests pass. I have some other interesting ideas for ways to augment it, but, for now, I just wanted to get the conversation started on ways this could be improved.

Possible improvements:
- Attempt to download MaxMind's database and build the artifacts used by the package (would require a MaxMind API key as a secret)
- Set up recurring CI job that downloads the latest database and, if it's newer than the one available on the last published version of the package, publishes a new package with it (would require an NPM token as a secret)

I've also noticed that npm automatically re-formats the current `package.json` file, should I also commit those changes? 