### PR TITLE
Updated npmjs search link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ really hard to get libgeoip built for Mac OSX without using the library from Mac
 why geoip-lite
 --------------
 
-So why are we called geoip-lite?  `npm` already has a [geoip package](http://search.npmjs.org/#/geoip) which provides a JavaScript
+So why are we called geoip-lite?  `npm` already has a [geoip package](https://www.npmjs.com/search?q=geoip) which provides a JavaScript
 binding around libgeoip from MaxMind.  The `geoip` package is fully featured and supports everything that the MaxMind APIs support,
 however, it requires `libgeoip` to be installed on your system.
 


### PR DESCRIPTION
The link present - http://search.npmjs.org/#/geoip - references a domain not existing anymore.
Current correct link: https://www.npmjs.com/search?q=geoip

Note: the context where the obsolete link is used might as well be obsolete, because https://www.npmjs.com/package/geoip is obviously obsolete and links back to this very package.
So if you decide to drop this part of README altogether or rewrite it, then disregard this PR.