### PR TITLE
update async version patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"updatedb-force": "node scripts/updatedb.js force"
 	},
 	"dependencies": {
-		"async": "2.1 - 2.6.3",
+		"async": "2.1 - 2.6.4",
 		"chalk": "4.1 - 4.1.2",
 		"iconv-lite": "0.4.13 - 0.6.3",
 		"ip-address": "5.8.9 - 5.9.4",


### PR DESCRIPTION
Related to https://github.com/geoip-lite/node-geoip/pull/237 but this PR updates async to 2.6.4 to address vulnerability without updating async to a new major version.

Test results

```
/usr/local/bin/npm test
> geoip-lite@1.4.4 pretest
> eslint .
> geoip-lite@1.4.4 test
> nodeunit --reporter=minimal test/tests.js
tests.js: ........
OK: 38 assertions (68ms)
Process finished with exit code 0
```