### PR TITLE
Fix custom data path behavior

### DIFF
--- a/lib/geoip.js
+++ b/lib/geoip.js
@@ -10,14 +10,10 @@ var async = require('async');
 
 var watcherName = 'dataWatcher';
 
-
-var geodatadir;
-
-if (typeof global.geodatadir === 'undefined'){
-	geodatadir = path.join(__dirname, '/../data/');
-} else {
-	geodatadir = global.geodatadir;
-}
+var geodatadir = path.resolve(
+	__dirname,
+	global.geodatadir || process.env.GEODATADIR || '../data/'
+);
 
 var dataFiles = {
 	city: path.join(geodatadir, 'geoip-city.dat'),

--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -36,15 +36,15 @@ var geodatadir = args.find(function(arg) {
 if (typeof geodatadir === 'undefined' && typeof process.env.GEODATADIR !== 'undefined') {
 	geodatadir = 'geodatadir='+process.env.GEODATADIR;
 }
-var dataPath = path.join(__dirname, '..', 'data');
+var dataPath = path.resolve(__dirname, '..', 'data');
 if (typeof geodatadir !== 'undefined') {
-	dataPath = path.join(process.cwd(), geodatadir.split('=')[1]);
+	dataPath = path.resolve(process.cwd(), geodatadir.split('=')[1]);
 	if (!fs.existsSync(dataPath)) {
 		console.log(chalk.red('ERROR') + ': Directory does\'t exist: ' + dataPath);
 		process.exit(1);
 	}
 }
-var tmpPath = path.join(__dirname, '..', 'tmp');
+var tmpPath = path.resolve(__dirname, '..', 'tmp');
 var countryLookup = {};
 var cityLookup = {};
 var databases = [


### PR DESCRIPTION
The custom data path behavior is inconsistent between the updater and library itself.
In the updater, a path relative to `CWD` hsa to be provided, there is no support for absolute paths.

In the library, the only way of specifying a custom data path is using the very clunky `global.geodatadir`, while updater can use env variable.

After this update, you can use
 - absolute paths in the updater
 - `process.env.GEODATADIR` for specifying the custom data dir for library