### PR TITLE
fix: add GEOTMPDIR env

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ geoip.startWatchingDataUpdate();
 
 This tool can be used with `npm run-script updatedb` to periodically update geo data on a running server.
 
+#### Environment variables
+
+The following environment variables can be set.
+
+```bash
+# Override the default node_modules/geoip-lite/data dir
+GEOTMPDIR=/some/path
+
+# Override the default node_modules/geoip-lite/tmp dir
+GEODATADIR=/some/path
+```
+
 Caveats
 -------
 

--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -44,7 +44,7 @@ if (typeof geodatadir !== 'undefined') {
 		process.exit(1);
 	}
 }
-var tmpPath = path.resolve(__dirname, '..', 'tmp');
+var tmpPath = process.env.GEOTMPDIR ? process.env.GEOTMPDIR : path.resolve(__dirname, '..', 'tmp');
 var countryLookup = {};
 var cityLookup = {};
 var databases = [


### PR DESCRIPTION
# Add GEOTMPDIR env var

- Allow overriding the default tmp dir `node_modules/geoip-lite/tmp` with GEOTMPDIR env var
- Update docs with undocumented GEODATADIR env