### PR TITLE
Bump ip-address to resolve vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"chalk": "4.1 - 4.1.2",
 				"iconv-lite": "0.4.13 - 0.6.3",
-				"ip-address": "5.8.9 - 5.9.4",
+				"ip-address": "^10.2.0",
 				"lazy": "1.0.11",
 				"yauzl": "^3.2.1"
 			},
@@ -691,17 +691,12 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "5.9.4",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
-			"integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"lodash": "^4.17.15",
-				"sprintf-js": "1.1.2"
-			},
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -733,12 +728,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"license": "MIT"
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
@@ -809,12 +798,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "10.2.4",
@@ -970,12 +953,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name"           :  "geoip-lite",
-	"version"        :  "2.0.1",
+	"version"        :  "2.0.2",
 	"description"    :  "A light weight native JavaScript implementation of GeoIP API from MaxMind",
 	"keywords"       :  ["geo", "geoip", "ip", "ipv4", "ipv6", "geolookup", "maxmind", "geolite"],
 	"homepage"       :  "https://github.com/geoip-lite/node-geoip",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"dependencies"   :  {
 		"chalk": "4.1 - 4.1.2",
 		"iconv-lite": "0.4.13 - 0.6.3",
-		"ip-address": "5.8.9 - 5.9.4",
+		"ip-address": "^10.2.0",
 		"lazy": "1.0.11",
 		"yauzl": "^3.2.1"
 	},

--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -389,8 +389,8 @@ async function processCountryData(src, dest) {
 				bsz = 10;
 
 				rngip = new Address4(fields[0]);
-				sip = parseInt(rngip.startAddress().bigInteger(),10);
-				eip = parseInt(rngip.endAddress().bigInteger(),10);
+				sip = Number(rngip.startAddress().bigInt());
+				eip = Number(rngip.endAddress().bigInt());
 	
 				b = Buffer.alloc(bsz);
 				b.fill(0);
@@ -499,8 +499,8 @@ async function processCityData(src, dest) {
 			bsz = 24;
 
 			rngip = new Address4(fields[0]);
-			sip = parseInt(rngip.startAddress().bigInteger(),10);
-			eip = parseInt(rngip.endAddress().bigInteger(),10);
+			sip = Number(rngip.startAddress().bigInt());
+			eip = Number(rngip.endAddress().bigInt());
 			locId = parseInt(fields[1], 10);
 			locId = cityLookup[locId];
 			b = Buffer.alloc(bsz);


### PR DESCRIPTION
Bumps ip-address to the latest version in 10, and unpins it so future minor and patch versions can be installed by projects that depend on this.

I wasn't able to test this because I don't have a license key lying around, but will double check it in a bit to make sure there isn't something dumb I'm doing here. I couldn't find a changelog for ip-address.